### PR TITLE
Missing dot in TM 2015

### DIFF
--- a/teammates/text_2015/teammates_2015.txt
+++ b/teammates/text_2015/teammates_2015.txt
@@ -169,7 +169,7 @@ Package overview contains test.driver, test.pageobjects, test.cases, and subpack
 test.driver contains infrastructure need for running the test driver.
 test.pageobjects contains abstractions of the pages as the appear on a Browser (i.e. SUTs).
 test.cases contains test cases.
-Sub packages contains x.cases.testdriver, x.cases.browsertests, x.cases.common, x.cases.logic, x.cases.storage
+Sub packages contains x.cases.testdriver, x.cases.browsertests, x.cases.common, x.cases.logic, x.cases.storage.
 x.cases.driver contains component test cases for testing test driver infrastructure.
 x.cases.browsertests contains system test cases for testing the UI.
 x.cases.common contains component test cases for testing the Common component.


### PR DESCRIPTION
@menof36go mentioned a missing dot in https://github.com/ArDoCo/Core/pull/286 . This causes wrongly indexed sentences. Thus, we missed some TLs.